### PR TITLE
Max steps now a parameter

### DIFF
--- a/Simplex/Solver.php
+++ b/Simplex/Solver.php
@@ -17,19 +17,22 @@ class Solver
 
 	/** @var array */
 	private $steps = array();
-	private $max_steps = 16;
+
+	/** @var int */
+	private $maxSteps;
 
 
 
-	/** @param  Task $task */
-	/** @param int $maxSteps (optional) */
-	function __construct(Task $task, int $maxSteps = null)
+	/**
+	 * @param  Task $task
+	 *
+ 	 * @param int $maxSteps
+	 */
+	function __construct(Task $task, $maxSteps = 16)
 	{
-		if ($maxSteps !== null) {
-			$this->max_steps = $maxSteps;
-		}
-
+		$this->maxSteps = (int) $maxSteps;
 		$this->steps[] = $task;
+
 		$this->solve();
 	}
 
@@ -39,14 +42,6 @@ class Solver
 	function getSteps()
 	{
 		return $this->steps;
-	}
-
-
-
-	/** @return int */
-	function getMaxSteps()
-	{
-		return $this->max_steps;
 	}
 
 
@@ -65,7 +60,7 @@ class Solver
 			$tbl = clone $tbl;
 			$this->steps[] = $tbl->nextStep();
 
-			if (count($this->steps) > $this->getMaxSteps()) {
+			if (count($this->steps) > $this->maxSteps) {
 				break ;
 			}
 		}

--- a/Simplex/Solver.php
+++ b/Simplex/Solver.php
@@ -25,8 +25,7 @@ class Solver
 
 	/**
 	 * @param  Task $task
-	 *
- 	 * @param int $maxSteps
+ 	 * @param  int $maxSteps
 	 */
 	function __construct(Task $task, $maxSteps = 16)
 	{

--- a/Simplex/Solver.php
+++ b/Simplex/Solver.php
@@ -17,16 +17,18 @@ class Solver
 
 	/** @var array */
 	private $steps = array();
-
-
-
-	const MAX_STEPS = 16;
+	private $max_steps = 16;
 
 
 
 	/** @param  Task $task */
-	function __construct(Task $task)
+	/** @param int $maxSteps (optional) */
+	function __construct(Task $task, int $maxSteps = null)
 	{
+		if ($maxSteps !== null) {
+			$this->max_steps = $maxSteps;
+		}
+
 		$this->steps[] = $task;
 		$this->solve();
 	}
@@ -37,6 +39,14 @@ class Solver
 	function getSteps()
 	{
 		return $this->steps;
+	}
+
+
+
+	/** @return int */
+	function getMaxSteps()
+	{
+		return $this->max_steps;
 	}
 
 
@@ -55,7 +65,7 @@ class Solver
 			$tbl = clone $tbl;
 			$this->steps[] = $tbl->nextStep();
 
-			if (count($this->steps) > self::MAX_STEPS) {
+			if (count($this->steps) > $this->getMaxSteps()) {
 				break ;
 			}
 		}


### PR DESCRIPTION
Previously, the max steps the solver would take was a constant. This
allows the user of the library to determine if they want more or less
max steps when using the solver.

The problem I was using this library for required more than the default 16 steps to solve, so I thought this change may be helpful for others.