### PR TITLE
Prevent faulty loops on a Fraction creation from decimals

### DIFF
--- a/Simplex/Fraction.php
+++ b/Simplex/Fraction.php
@@ -259,7 +259,7 @@ class Fraction
 
 		$decpart = (float) ($n - (int) $n);
 		$mlp = pow(10, strlen($decpart) - 2 - ($n < 0 ? 1 : 0));
-		return new self($n * $mlp, $mlp);
+		return new self((int) ($n * $mlp), $mlp);
 	}
 
 }

--- a/tests/FractionTest.phpt
+++ b/tests/FractionTest.phpt
@@ -29,6 +29,10 @@ $f = new Fraction(8, 1/4);
 Assert::equal('32', (string) $f);
 
 
+$f = new Fraction(0.14);
+Assert::equal('7/50', (string) $f);
+
+
 $a = new Fraction(1, 4);
 $b = new Fraction(2, 3);
 Assert::equal('11/12', (string) $a->add($b));


### PR DESCRIPTION
Found this issue sometimes leading to "[Exception] Division by zero.".

Test is covering the example of such behavior:
$f = new Fraction(0.14) gives 5468750000000001 / 39062500000000000 (instead of 5/70)